### PR TITLE
Design: 로그아웃 부분 디자인

### DIFF
--- a/src/components/Header/LoginAfterHeader.jsx
+++ b/src/components/Header/LoginAfterHeader.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import * as LAHe from '../../styles/LoginAfterHeaderStyle';
+import Logout from '../../pages/auth/Logout';
 
 const LoginAfterHeader = () => {
 	const navigate = useNavigate();
@@ -31,10 +32,6 @@ const LoginAfterHeader = () => {
 		navigate('/mypage');
 	};
 
-	const handleLogoutClick = () => {
-		navigate('/logout');
-	};
-
 	return (
 		<LAHe.Header>
 			<LAHe.Logo onClick={handleHomeClick}>ProLink</LAHe.Logo>
@@ -54,7 +51,7 @@ const LoginAfterHeader = () => {
 				<LAHe.Tab onClick={handleMyPageClick} $active={activeTab === '/mypage'}>
 					마이페이지
 				</LAHe.Tab>
-				<LAHe.Tab2 onClick={handleLogoutClick}>로그아웃</LAHe.Tab2>
+					<Logout />
 			</LAHe.NavMenu>
 		</LAHe.Header>
 	);

--- a/src/pages/auth/Logout.jsx
+++ b/src/pages/auth/Logout.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
+import * as LAHe from '../../styles/LoginAfterHeaderStyle';
+import { useNavigate } from 'react-router-dom';
 
 
 const Logout = ({ }) => {
+  const navigate = useNavigate();
 
+  const handleLogoutClick = () => {
+    const confirmed = window.confirm('로그아웃하시겠습니까?')
+		if (confirmed) {
+      navigate('/');
+    }
+    
+	};
 
   return (
     <>
-        <div>logout 페이지입니다.</div>
+        <LAHe.Tab2 onClick={handleLogoutClick}>로그아웃</LAHe.Tab2>
     </>
   )
 }

--- a/src/styles/Modal/LogoutStyle.js
+++ b/src/styles/Modal/LogoutStyle.js
@@ -1,0 +1,1 @@
+import styled from "styled-components";


### PR DESCRIPTION
## 🚩 관련 이슈

- close #11 

## 📋 구현 기능 명세

- [x] 로그아웃 부분 UI 수정 

## 📌 PR Point

- 로그아웃 부분 디자인 하였습니다. (로그아웃 클릭 -> 취소 시 창 닫기/ 확인 시 로그인 전 메인홈으로)

## 📸 결과물 스크린샷
![image](https://github.com/user-attachments/assets/7de4de90-31ab-4a72-95b6-ec7b856714aa)
![image](https://github.com/user-attachments/assets/b454ba83-c93f-417e-a360-cd3c8c142fcb)
![image](https://github.com/user-attachments/assets/910733c0-5756-4e4c-924a-9dba687b1fae)

## 🛠️ 테스트
- 로그아웃 화면 디자인

## 🚀 API Endpoint
- http://localhost:3000/loginAfterHome
- http://localhost:3000/

